### PR TITLE
Healthcheck

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,7 +9,7 @@ ARG PYPI_HOST
 RUN apk update && \
     apk add --update nodejs npm && \
     apk add --update --no-cache netcat-openbsd && \
-    apk add postgresql-dev gcc python3-dev musl-dev
+    apk add postgresql-dev gcc python3-dev musl-dev curl
 
 RUN adduser -D backend
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - elasticsearch
       - db
     healthcheck:
-      test: "curl http://web:80"
+      test: "curl http://web:5000"
       interval: "1s"
       timeout: "3s"
       retries: 60


### PR DESCRIPTION
Pour le healthcheck du conteneur web, curl n'était pas dans l'image construite avec le dockerfile.

Et dans le docker compose, le port pour le test n'était pas le bon.